### PR TITLE
Add csv separator for example data to work

### DIFF
--- a/src/pipelines/tasks/select_features.py
+++ b/src/pipelines/tasks/select_features.py
@@ -30,10 +30,10 @@ def select_features():
 
     storage_hook.get_file(local_input_path, 'raw', remote_input_path)
 
-    df = pd.read_csv(local_input_path)
+    df = pd.read_csv(local_input_path, sep=';')
     df = df[feature_names]
 
-    df.to_csv(local_output_path)
+    df.to_csv(local_output_path, sep=';')
 
     with open(local_output_path, 'rb') as output_file:
         storage_hook.upload('intermediate', remote_output_path, output_file, overwrite=True)


### PR DESCRIPTION
The select_features task in the prepare_dataset DAG currently fails due to an incorrect default separator that is being used by pandas.read_csv. The default separator is "," while the separator in the example data is ";".